### PR TITLE
missing file added

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+timeout = 60


### PR DESCRIPTION
A missing pytest.ini is the cause for  FLAKE8 - AttributeError: 'Application' object has no attribute 'parse_preliminary_op

closes #21 