### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,14 @@ import os
 # sys.path.insert(0, os.path.abspath('.'))
 # readthedocs has no past.builtins
 try:
-    from fslib.version import __version__
-except ImportError:
-    pass
+    from past.builtins import execfile
+except ImportError as ex:
+    logging.error("%s", ex)
+try:
+    execfile("../fslib/version.py")
+except NameError:
+    exec(open("../fslib/version.py").read())
+
 on_rtd = os.environ.get("READTHEDOCS") == "True"
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
There appear to be some python formatting errors in c23237b191ab3208c811733715d04f457c8c4ddb. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.