### PR TITLE
Do not retry failed tests in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,6 @@
 name: Pytest fs_filepicker
 
-on:                                                                                  
+on:
   workflow_call:
     inputs:
       xdist:
@@ -82,11 +82,7 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate fsfp-${{ inputs.branch_name }}-env \
-        && pytest -v --durations=20 --reverse --cov=fslib tests \
-        || (for i in {1..5} \
-          ; do pytest tests -v --durations=0 --reverse --last-failed --lfnf=none \
-          && break \
-        ; done)
+        && pytest -v --durations=20 --reverse --cov=fslib tests
 
     - name: Run tests in parallel
       if: ${{ success() && inputs.xdist == 'yes' }}
@@ -96,15 +92,11 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate fsfp-${{ inputs.branch_name }}-env \
-        && pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests \
-        || (for i in {1..5} \
-          ; do pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests --last-failed --lfnf=none \
-          && break \
-        ; done)
+        && pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests
 
     - name: Collect coverage
       if: ${{ success() && inputs.event_name == 'push' && inputs.branch_name == 'develop' && inputs.xdist == 'no'}}
-      env: 
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE \

--- a/.github/workflows/testing_gsoc.yml
+++ b/.github/workflows/testing_gsoc.yml
@@ -70,11 +70,7 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate fsfp-develop-env \
-        && pytest -v --durations=20 --reverse --cov=mslib tests \
-        || (for i in {1..5} \
-          ; do pytest tests -v --durations=0 --reverse --last-failed --lfnf=none \
-          && break \
-        ; done)
+        && pytest -v --durations=20 --reverse --cov=mslib tests
 
 
     - name: Run tests in parallel
@@ -85,15 +81,11 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate fsfp-develop-env \
-        && pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests \
-        || (for i in {1..5} \
-          ; do pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests --last-failed --lfnf=none \
-          && break \
-        ; done)
+        && pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests
 
     - name: Collect coverage
       if: ${{ success() && inputs.event_name == 'push' && inputs.branch_name == 'develop' && inputs.xdist == 'no'}}
-      env: 
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE \


### PR DESCRIPTION
Tests that do not consistently pass are broken tests and should be fixed. Failed tests should not be retried to avoid accidentally adding new broken tests.

Since apparently there are no tests that actually require rerunning right now this is a simple change. I would like this change to happen in MSS as well, but the test suite there currently needs the retries.